### PR TITLE
wikipedia.py and wikipedia-categories.py updates

### DIFF
--- a/enrichment/wikipedia-categories.py
+++ b/enrichment/wikipedia-categories.py
@@ -92,7 +92,7 @@ def get_wptitle(record):
                     _sameAs = _base + page_data["title"]
                     _id = _base + "?curid={}".format(page_id)
                     _name = page_data["title"].split(":")[1]
-                    obj = {"id": _id, "sameAs": _sameAs, "name": _name}
+                    obj = {"@id": _id, "sameAs": _sameAs, "name": _name}
                     retobj[cc] = litter(retobj.get(cc),obj)
                     changed = True
             except KeyError:
@@ -129,7 +129,7 @@ def get_wptitle(record):
                 #record["name"][cc] = litter(record["name"][cc], info["title"])
                 #changed = True
     if changed:
-        record["wp_categories"] = retobj
+        record["category"] = retobj
         return record
     return None
 

--- a/enrichment/wikipedia-categories.py
+++ b/enrichment/wikipedia-categories.py
@@ -89,8 +89,8 @@ def get_wptitle(record):
             try:
                 pages = wd_response.json()["query"]["pages"]
                 for page_id, page_data in pages.items():
-                    _sameAs = _base + "?curid={}".format(page_data["title"])
-                    _id = _base + page_id
+                    _sameAs = _base + page_data["title"]
+                    _id = _base + "?curid={}".format(page_id)
                     _name = page_data["title"].split(":")[1]
                     obj = {"id": _id, "sameAs": _sameAs, "name": _name}
                     retobj[cc] = litter(retobj.get(cc),obj)

--- a/enrichment/wikipedia-categories.py
+++ b/enrichment/wikipedia-categories.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+""" Tool, to enrich elasticsearch data with existing wikipedia attributes
+    connected to a record by an (already existing) wikidata-ID
+
+    Currently sites from the german, english, polish, and czech wikipedia are
+    enrichted.
+
+    Input:
+        elasticsearch index OR
+        STDIN (as jsonl)
+
+    Output:
+        on STDOUT
+"""
+import argparse
+import json
+import sys
+import requests
+import urllib
+from es2json import esgenerator, isint, eprint, litter
+
+lookup_table_wpSites = {
+        "cswiki": {
+                    "@id": "https://cs.wikipedia.org",
+                    "preferredName": "Wikipedia (Tschechisch)",
+                    "abbr": "cswiki"
+                    },
+        "dewiki": {
+                    "abbr": "dewiki",
+                    "preferredName": "Wikipedia (Deutsch)",
+                    "@id": "https://de.wikipedia.org"
+                    },
+        "plwiki": {
+                    "abbr": "plwiki",
+                    "preferredName": "Wikipedia (Polnisch)",
+                    "@id": "https://pl.wikipedia.org"
+                    },
+        "enwiki": {
+                    "abbr": "enwiki",
+                    "preferredName": "Wikipedia (Englisch)",
+                    "@id": "https://en.wikipedia.org"
+                    },
+        }
+
+
+def get_wptitle(record):
+    """
+    * iterates through all sameAs Links to extract a wikipedia-link
+    * enriches wikipedia sites if they are within lookup_table_wpSites
+      (i.e. currently german, english, polish, czech)
+
+    returns: None (if record has not been changed)
+             enriched record (dict, if record has changed)
+    """
+    wp_uri = None
+    wp_title = None
+    cc = None  # countrycode
+    retobj = {}
+    for _id in [x["@id"] for x in record["sameAs"]]:
+        if "wikipedia" in _id:
+            wp_uri = _id
+            wp_title = wp_uri.split("/")[-1]
+            cc = wp_uri.split("/")[2].split(".")[0]
+
+
+            headers = {
+                    'User-Agent': 'lod-enrich-wikipedia-attributes-bot/0.1'
+                                   '(https://github.com/slub/esmarc) '
+                                   'python-requests/2.22'
+                    }
+            url = "https://{}.wikipedia.org/w/api.php".format(cc)
+            wd_response = requests.get(url,
+                                       headers=headers,
+                                       params={'action': 'query',
+                                               'cllimit': 500,
+                                               'clshow': '!hidden',
+                                               'titles': wp_title,
+                                               'prop': 'categories',
+                                               'format': 'json'})
+
+            if not wd_response.ok:
+                eprint("wikipedia: Connection Error {status}: \'{message}\'"
+                        .format(status=wd_response.status_code,
+                                message=wd_response.content)
+                        )
+                return None
+            ## related wikipedia links:
+            _base = "https://{}.wikipedia.org/wiki/".format(cc)
+            try:
+                pages = wd_response.json()["query"]["pages"]
+                for page_id, page_data in pages.items():
+                    for category in page_data["categories"]:
+                        _id = _base + "{}".format(category["title"])
+                        _name = category["title"].split(":")[1]
+                        obj = {"id": _id, "name": _name}
+                        retobj[cc] = litter(retobj.get(cc),obj)
+                        changed = True
+            except KeyError:
+                eprint("wikipedia: Data Error for Record:")
+                eprint("{record}\'\n\'{wp_record}\'".format(record=record,
+                                            wp_record=wd_response.content))
+                return None
+            
+    ## list of all abbreviations for publisher in record's sameAs
+    #abbrevs = list(x["publisher"]["abbr"] for x in record["sameAs"])
+
+    #changed = False
+    #for wpAbbr, info in sites.items():
+        #if wpAbbr in lookup_table_wpSites:
+            #wikip_url = lookup_table_wpSites[wpAbbr]["@id"] + "/wiki/{title}"\
+                        #.format(title=info["title"])
+            #newSameAs = {"@id": wikip_url,
+                         #"publisher": lookup_table_wpSites[wpAbbr],
+                         #"isBasedOn": {
+                             #"@type": "Dataset",
+                             #"@id": wp_uri
+                             #}
+                         #}
+            #if wpAbbr not in abbrevs:
+                #record["sameAs"].append(newSameAs)
+                #changed = True
+            #if not record.get("name"):
+                #record["name"] = {}
+            #cc = wpAbbr[:2]  # countrycode
+            #if cc not in record["name"]:
+                #record["name"][cc] = [info["title"]]
+                #changed = True
+            #if info["title"] not in record["name"][cc]:
+                #record["name"][cc] = litter(record["name"][cc], info["title"])
+                #changed = True
+    if changed:
+        record["wp_categories"] = retobj
+        return record
+    return None
+
+def _make_parser():
+    """ Generates argument parser with all necessarry parameters.
+    :returns script's arguments (host, port, index, type, id,
+             searchserver, server, stdin, pipeline)
+    :rtype   argparse.ArgumentParser
+    """
+
+    p = argparse.ArgumentParser(description=__doc__,
+                formatter_class=argparse.RawDescriptionHelpFormatter)   # noqa
+    inputgroup = p.add_mutually_exclusive_group(required=True)
+    inputgroup.add_argument('-server', type=str,                        # noqa
+                   help="use http://host:port/index/type[/id]. "
+                        "Defines the Elasticsearch node and its index "
+                        "for the input data. The last part of the path [id] "
+                        "is optional and can be used for retrieving a single "
+                        "document")
+    inputgroup.add_argument('-stdin', action="store_true",              # noqa
+                   help="get data from stdin. Might be used with -pipeline.")
+    p.add_argument('-pipeline', action="store_true",
+                   help="output every record (even if not enriched) "
+                        "to put this script into a pipeline")
+    return p
+
+
+_p = _make_parser()
+
+# extend docstring by argparse's help output
+# → needed for the documentation to show command line parameters
+__doc__ = _p.format_help()
+
+
+def run():
+
+    args = _p.parse_args()
+    if args.server:
+        srv = urllib.parse.urlparse(args.server)
+        host = srv.hostname
+        port = srv.port
+        splitpath = srv.path.split("/")
+        index = splitpath[1]
+        doc_type = splitpath[2]
+        if len(splitpath) > 3:
+            doc_id = splitpath[3]
+        else:
+            doc_id = None
+    if args.stdin:
+        iterable = sys.stdin
+    else:
+        es_query = {
+            "query": {
+                "match": {"sameAs.publisher.abbr.keyword": "WIKIDATA"}
+                }
+            }
+        iterable = esgenerator(host=host, port=port,
+                               index=index, type=doc_type, id=doc_id,
+                               headless=True, body=es_query)
+
+    for rec_in in iterable:
+        if args.stdin:
+            rec_in = json.loads(rec_in)
+
+        rec_out = get_wptitle(rec_in)
+
+        if rec_out:
+            print(json.dumps(rec_out, indent=None))
+        elif args.pipeline:
+            print(json.dumps(rec_in, indent=None))
+
+
+if __name__ == "__main__":
+    run()

--- a/enrichment/wikipedia-categories.py
+++ b/enrichment/wikipedia-categories.py
@@ -55,11 +55,12 @@ def get_wptitle(record):
     wp_uri = None
     wp_title = None
     cc = None  # countrycode
+    changed = False
     retobj = {}
     for _id in [x["@id"] for x in record["sameAs"]]:
         if "wikipedia" in _id:
             wp_uri = _id
-            wp_title = wp_uri.split("/")[-1]
+            wp_title = urllib.parse.unquote(wp_uri.split("/")[-1])
             cc = wp_uri.split("/")[2].split(".")[0]
 
 

--- a/enrichment/wikipedia-categories.py
+++ b/enrichment/wikipedia-categories.py
@@ -18,7 +18,7 @@ import urllib
 from es2json import esgenerator, eprint, litter
 
 
-def get_wptitle(record):
+def get_wpcategories(record):
     """
     * iterates through all sameAs Links to extract the
       link(s) to the wiki-site
@@ -140,7 +140,7 @@ def run():
         if args.stdin:
             rec_in = json.loads(rec_in)
 
-        rec_out = get_wptitle(rec_in)
+        rec_out = get_wpcategories(rec_in)
 
         if rec_out:
             print(json.dumps(rec_out, indent=None))

--- a/enrichment/wikipedia-categories.py
+++ b/enrichment/wikipedia-categories.py
@@ -73,12 +73,11 @@ def get_wptitle(record):
             wd_response = requests.get(url,
                                        headers=headers,
                                        params={'action': 'query',
-                                               'cllimit': 500,
-                                               'clshow': '!hidden',
+                                               'generator': 'categories',
                                                'titles': wp_title,
-                                               'prop': 'categories',
+                                               'gcllimit': 500,
+                                               'prop': 'info',
                                                'format': 'json'})
-
             if not wd_response.ok:
                 eprint("wikipedia: Connection Error {status}: \'{message}\'"
                         .format(status=wd_response.status_code,
@@ -90,12 +89,12 @@ def get_wptitle(record):
             try:
                 pages = wd_response.json()["query"]["pages"]
                 for page_id, page_data in pages.items():
-                    for category in page_data["categories"]:
-                        _id = _base + "{}".format(category["title"])
-                        _name = category["title"].split(":")[1]
-                        obj = {"id": _id, "name": _name}
-                        retobj[cc] = litter(retobj.get(cc),obj)
-                        changed = True
+                    _sameAs = _base + "?curid={}".format(page_data["title"])
+                    _id = _base + page_id
+                    _name = page_data["title"].split(":")[1]
+                    obj = {"id": _id, "sameAs": _sameAs, "name": _name}
+                    retobj[cc] = litter(retobj.get(cc),obj)
+                    changed = True
             except KeyError:
                 eprint("wikipedia: Data Error for Record:")
                 eprint("{record}\'\n\'{wp_record}\'".format(record=record,

--- a/enrichment/wikipedia.py
+++ b/enrichment/wikipedia.py
@@ -116,8 +116,8 @@ def get_wpinfo(record):
     try:
         sites = wd_response.json()["entities"][wd_id]["sitelinks"]
     except KeyError:
-        eprint("wikipedia: Data Error for Record:")
-        eprint("\'{record}\'\n\'{wp_record}\'"
+        eprint("wikipedia: Data Error for Record:\n"
+               "\'{record}\'\n\'{wp_record}\'"
                .format(record=record, wp_record=wd_response.content))
         return None
 

--- a/enrichment/wikipedia.py
+++ b/enrichment/wikipedia.py
@@ -115,7 +115,7 @@ def get_wptitle(record):
             if cc not in record["name"]:
                 record["name"][cc] = [info["title"]]
                 changed = True
-            else:
+            if info["title"] not in record["name"][cc]:
                 record["name"][cc] = litter(record["name"][cc], info["title"])
                 changed = True
     if changed:

--- a/enrichment/wikipedia.py
+++ b/enrichment/wikipedia.py
@@ -63,7 +63,7 @@ def build_abbrevs(sameAsses):
     return abbrevs
 
 
-def get_wptitle(record):
+def get_wpinfo(record):
     """
     * iterates through all sameAs Links to extract a wikidata-ID
     * requests wikipedia sites connected to the wd-Id
@@ -72,6 +72,7 @@ def get_wptitle(record):
     * if we get an new wikipedia link from wikidata, but we
       already got an old entry from other as obsolete defined sources,
       we delete the obsolete entry and append the new entry
+    * enriches multilingual names if they are within lookup_table_wpSites
 
     :returns None (if record has not been changed)
              enriched record (dict, if record has changed)
@@ -145,7 +146,7 @@ def get_wptitle(record):
                 abbrevs = build_abbrevs(record["sameAs"])
                 changed = True
 
-            # name object enrichment
+            # multilingual name object enrichment
             if not record.get("name"):
                 record["name"] = {}
             cc = wpAbbr[:2]  # countrycode
@@ -220,7 +221,7 @@ def run():
         if args.stdin:
             rec_in = json.loads(rec_in)
 
-        rec_out = get_wptitle(rec_in)
+        rec_out = get_wpinfo(rec_in)
 
         if rec_out:
             print(json.dumps(rec_out, indent=None))

--- a/enrichment/wikipedia.py
+++ b/enrichment/wikipedia.py
@@ -28,17 +28,17 @@ lookup_table_wpSites = {
         "dewiki": {
                     "abbr": "dewiki",
                     "preferredName": "Wikipedia (Deutsch)",
-                    "@id": "http://de.wikipedia.org"
+                    "@id": "https://de.wikipedia.org"
                     },
         "plwiki": {
                     "abbr": "plwiki",
                     "preferredName": "Wikipedia (Polnisch)",
-                    "@id": "http://pl.wikipedia.org"
+                    "@id": "https://pl.wikipedia.org"
                     },
         "enwiki": {
                     "abbr": "enwiki",
                     "preferredName": "Wikipedia (Englisch)",
-                    "@id": "http://en.wikipedia.org"
+                    "@id": "https://en.wikipedia.org"
                     },
         }
 

--- a/enrichment/wikipedia.py
+++ b/enrichment/wikipedia.py
@@ -5,6 +5,8 @@ to a record by an (already existing) wikidata-ID
 
 Currently sites from the de, en, pl, and cz wikipedia are enrichted.
 
+Can be configured to overwrite certain data sources to update obsolete/false links.
+
 Input:
     elasticsearch index OR
     STDIN (as jsonl)
@@ -19,6 +21,10 @@ import requests
 import urllib
 from es2json import esgenerator, eprint, litter
 
+# list of data source which should be updated if we get a new wikipedia-link
+obsolete_isBasedOns = ['hub.culturegraph.org']
+
+# lookup table of which wikipedias to enrich
 lookup_table_wpSites = {
         "cswiki": {
                     "abbr": "cswiki",
@@ -81,8 +87,6 @@ def get_wpinfo(record):
     wd_uri = None
     wd_id = None
 
-    # list of data source which should be updated if we get a new wikipedia-link
-    obsolete_isBasedOns = ['hub.culturegraph.org']
 
     for _id in [x["@id"] for x in record["sameAs"]]:
         if "wikidata" in _id:

--- a/enrichment/wikipedia.py
+++ b/enrichment/wikipedia.py
@@ -47,15 +47,11 @@ lookup_table_wpSites = {
 
 def build_abbrevs(sameAsses):
     """
-    builds a little helper dictionary with the abbreviations
-    of the current record, so we can check from which publisher
-    each abbreviation is originating, along with the position
-    in the records sameAs array, of course this helper dicitionary
-    needs to get updated each time the sameAs array of the record
-    gets changed, because the position value of the abbreviations
-    get changed. position value is needed for deletions, because we
-    want to delete entityfacts wikipedia entries when we get the
-    wikipedia entries by wikidata
+    builds a little helper dictionary with the sameAs abbreviations of the
+    current record, so we can check from which publisher each sameAs is
+    originating, along with the position in the records sameAs array.
+    position value is needed to update obsolete wikipedia entries based on the
+    isBasedOn provenance list
     :returns helper dictionary
     :rtype dict
     """
@@ -86,7 +82,6 @@ def get_wpinfo(record):
     """
     wd_uri = None
     wd_id = None
-
 
     for _id in [x["@id"] for x in record["sameAs"]]:
         if "wikidata" in _id:
@@ -143,11 +138,11 @@ def get_wpinfo(record):
             if wpAbbr not in abbrevs:
                 record["sameAs"].append(newSameAs)
                 changed = True
-                abbrevs = build_abbrevs(record["sameAs"])
+
+            # we already got an wikipedia link for that language, but the
+            # originating data source is obsolete, so we update
             elif abbrevs.get(wpAbbr) and abbrevs[wpAbbr]["host"] in obsolete_isBasedOns:
-                del record["sameAs"][abbrevs[wpAbbr]["pos"]]
-                record["sameAs"].append(newSameAs)
-                abbrevs = build_abbrevs(record["sameAs"])
+                record["sameAs"][abbrevs[wpAbbr]["pos"]] = newSameAs
                 changed = True
 
             # multilingual name object enrichment

--- a/enrichment/wikipedia.py
+++ b/enrichment/wikipedia.py
@@ -17,7 +17,7 @@ import json
 import sys
 import requests
 import urllib
-from es2json import esgenerator, isint, eprint
+from es2json import esgenerator, isint, eprint, litter
 
 lookup_table_wpSites = {
         "cswiki": {
@@ -108,6 +108,15 @@ def get_wptitle(record):
                          }
             if wpAbbr not in abbrevs:
                 record["sameAs"].append(newSameAs)
+                changed = True
+            if not record.get("name"):
+                record["name"] = {}
+            cc = wpAbbr[:2]  # countrycode
+            if cc not in record["name"]:
+                record["name"][cc] = [info["title"]]
+                changed = True
+            else:
+                record["name"][cc] = litter(record["name"][cc], info["title"])
                 changed = True
     if changed:
         return record


### PR DESCRIPTION
wikipedia.py now overwrites entityfacts wikipedia links
wikipedia-categories.py uses pageIDs instead of wikipedia-titles. wikipedia-titles get written to .sameAs.